### PR TITLE
Fix "Maximum call stack size exceeded" error for collections with a lot items (#127)

### DIFF
--- a/jquery.collection.js
+++ b/jquery.collection.js
@@ -740,11 +740,9 @@
                     if (that.hasClass(settings.user_prefix + suffix)) {
                         that.addClass(settings.prefix + suffix);
                     }
-                    that.find('*').each(function () {
+                    that.find('.' + settings.user_prefix + suffix).each(function () {
                         var here = $(this);
-                        if (here.hasClass(settings.user_prefix + suffix)) {
-                            here.addClass(settings.prefix + suffix);
-                        }
+                        here.addClass(settings.prefix + suffix);
                     });
                 });
             });


### PR DESCRIPTION
This fixes issue #127 for me.

![image](https://user-images.githubusercontent.com/4896363/156896325-88c5d4b9-af54-4784-8457-595efe6e3ce9.png)

See changes.
It should do the same as using `find('*').... hasClass`



